### PR TITLE
lab_workarounds: use upstream fix to prevent dockerized docker

### DIFF
--- a/lab_workarounds.mk
+++ b/lab_workarounds.mk
@@ -4,9 +4,4 @@ PREFLASH_DELAY=10
 
 # The ZTIMER_MSEC seems to be broken on some compilers so we force docker
 # to ensure a working compiler.
-# We also want to make sure the we are not doing any docker in docker
-# shenanigans.
-USER=$(shell whoami)
-ifneq ($(USER),riotbuild)
-  export BUILD_IN_DOCKER=1
-endif
+BUILD_IN_DOCKER ?= 1


### PR DESCRIPTION
Recursive docker has been fixed upstream with https://github.com/RIOT-OS/RIOT/pull/20638